### PR TITLE
fix: Correct 20250821W2-E2EEncryptedChat entry in README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository serves as:
 
 | Implementation | Date | Domain | Status | Quality Score | Time Reduction |
 |---------------|------|--------|--------|---------------|----------------|
-| [20250821W-E2EEncryptedChat](#-20250821w-e2eencryptedchat) | 2025-08-21 | Security/Messaging | ✅ Complete | **97%** (A+) | **99.5%** |
+| [20250821W2-E2EEncryptedChat](#-20250821w2-e2eencryptedchat) | 2025-08-21 | Security/Messaging | ✅ Complete | **95%** (A+) | **99%** |
 | [20250821W-E2EEncryptedChat](#-20250821w-e2eencryptedchat) | 2025-08-21 | Security/Messaging | ✅ Complete | **97%** (A+) | **99.5%** |
 | [20250821U-E2EEncryptedChat](#-20250821u-e2eencryptedchat) | 2025-08-21 | Security/Messaging | ✅ Complete | **96%** (A+) | **99.8%** |
 | [20250820W-E2EEncryptedChat](#-20250820w-e2eencryptedchat) | 2025-08-20 | Security/Messaging | ✅ Complete | **96%** (A+) | **98%** |


### PR DESCRIPTION
## Problem
The README table had an incorrect entry showing duplicate `20250821W-E2EEncryptedChat` instead of the correct `20250821W2-E2EEncryptedChat`.

## Solution
- Fixed the first table entry to correctly show `20250821W2-E2EEncryptedChat`
- Updated quality score to 95% (A+) and time reduction to 99%
- Maintained proper chronological order

## Changes
- Line 21: Fixed table entry from `20250821W` to `20250821W2`
- Updated anchor link and stats to match the actual implementation

## Result
Table now correctly shows:
```
| [20250821W2-E2EEncryptedChat](#-20250821w2-e2eencryptedchat) | 2025-08-21 | Security/Messaging | ✅ Complete | **95%** (A+) | **99%** |
| [20250821W-E2EEncryptedChat](#-20250821w-e2eencryptedchat) | 2025-08-21 | Security/Messaging | ✅ Complete | **97%** (A+) | **99.5%** |
```

🤖 Generated with [Claude Code](https://claude.ai/code)